### PR TITLE
Stop encoding write key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@june-so/analytics-next",
-  "version": "1.36.4",
+  "version": "1.36.5",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/pkg/index.js",

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const version = '1.36.4'
+export const version = '1.36.5'

--- a/src/plugins/analytics-node/index.ts
+++ b/src/plugins/analytics-node/index.ts
@@ -11,8 +11,6 @@ interface AnalyticsNodeSettings {
   version: string
 }
 
-const btoa = (val: string): string => Buffer.from(val).toString('base64')
-
 export async function post(
   event: SegmentEvent,
   writeKey: string
@@ -22,7 +20,7 @@ export async function post(
     headers: {
       'Content-Type': 'application/json',
       'User-Agent': 'analytics-node-next/latest',
-      Authorization: `Basic ${btoa(writeKey)}`,
+      Authorization: `Basic ${writeKey}`,
     },
     body: JSON.stringify(event),
   })


### PR DESCRIPTION
We seem to be encoding the writeKey with the Node SDK but not decoding it in the controller itself. Seeing 401s with the Node SDK even though the API key is correctly set up.

<img width="599" alt="image" src="https://user-images.githubusercontent.com/7032866/178746400-dab5ab2a-c02b-412c-828a-dbd49c27e610.png">

https://github.com/juneHQ/june/blob/323496173068bbfb92f4455115758928ce1a7e71/api/app/controllers/sdk/base_controller.rb#L35-L45